### PR TITLE
Development was not working. fix development default_url_options

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,8 +1,8 @@
 Wripe::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  app_base = URI.new(ENV['APP_BASE'] || 'https://wri.pe')
+  app_base = URI(ENV['APP_BASE'] || 'https://wri.pe')
   Rails.application.routes.default_url_options = {
-    protocol: app_base.protocol,
+    protocol: app_base.scheme,
     host: app_base.host
   }
 


### PR DESCRIPTION
default develpment config was not work. it change worked ruby ruby 2.0.0-p195 & 2.1.1p76.

```
$ be rake sunspot:solr:run

rake aborted!
NoMethodError: undefined method `new' for URI:Module
/Users/yudai/sandbox/test/open-wripe/config/environments/development.rb:3:in `block in <top (required)>'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/railtie/configurable.rb:24:in `class_eval'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/railtie/configurable.rb:24:in `configure'
/Users/yudai/sandbox/test/open-wripe/config/environments/development.rb:1:in `<top (required)>'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.3/lib/active_support/dependencies.rb:229:in `require'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.3/lib/active_support/dependencies.rb:229:in `block in require'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.3/lib/active_support/dependencies.rb:214:in `load_dependency'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.3/lib/active_support/dependencies.rb:229:in `require'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/engine.rb:591:in `block (2 levels) in <class:Engine>'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/engine.rb:590:in `each'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/engine.rb:590:in `block in <class:Engine>'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/initializable.rb:30:in `instance_exec'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/initializable.rb:30:in `run'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/initializable.rb:55:in `block in run_initializers'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/initializable.rb:44:in `each'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/initializable.rb:44:in `tsort_each_child'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/initializable.rb:54:in `run_initializers'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/application.rb:215:in `initialize!'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/railtie/configurable.rb:30:in `method_missing'
/Users/yudai/sandbox/test/open-wripe/config/environment.rb:8:in `<top (required)>'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.3/lib/active_support/dependencies.rb:229:in `require'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.3/lib/active_support/dependencies.rb:229:in `block in require'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.3/lib/active_support/dependencies.rb:214:in `load_dependency'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/activesupport-4.0.3/lib/active_support/dependencies.rb:229:in `require'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/application.rb:189:in `require_environment!'
/Users/yudai/sandbox/test/open-wripe/vendor/bundle/ruby/2.0.0/gems/railties-4.0.3/lib/rails/application.rb:250:in `block in run_tasks_blocks'
Tasks: TOP => sunspot:solr:run => environment
(See full trace by running task with --trace)
```
