### PR TITLE
Enable enabling or disabling ActiveRecordAsync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # Ignore bundler config
 /.bundle
+vendor/bundle
 
 # Ignore the default SQLite database.
 /db/*.sqlite3
@@ -26,6 +27,7 @@
 .DS_Store
 
 # Ignore your setting files
+config/application.yml
 config/async.yml
 config/evernote.yml
 config/github.yml

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,8 @@ end
 gem 'jquery-rails'
 gem 'less-rails'
 
+gem 'settingslogic'
+
 # To use ActiveModel has_secure_password
 # gem 'bcrypt-ruby', '~> 3.0.0'
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ https://wri.pe source code.
 ### set up
 
 ```
+cp config/application-sample.yml config/application.yml
 cp config/async-sample.yml config/async.yml
 cp config/evernote-sample.yml config/evernote.yml
 cp config/github-sample.yml config/github.yml

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery
-  around_filter :active_record_queue_filter
+  around_filter :active_record_queue_filter if !Settings.flags.disable_ar_async
 
   private
   def required_login

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -1,0 +1,4 @@
+class Settings < Settingslogic
+  source "#{Rails.root}/config/application.yml"
+  namespace Rails.env
+end

--- a/config/application-sample.yml
+++ b/config/application-sample.yml
@@ -1,0 +1,12 @@
+defaults: &defaults
+  flags:
+    disable_ar_async: off
+
+development:
+  <<: *defaults
+
+test:
+  <<: *defaults
+
+production:
+  <<: *defaults


### PR DESCRIPTION
open-wripe uses Amazon SQS at ActiceRecordAsync for asynchronous execution of active record.
but using Amazon SQS is too exaggerated at local environment.

I suggest enabling or disabling ActiveRecordAsync.

This pull request enables to enable or disable ActiveRecordAsync.
